### PR TITLE
Support downloading OpenSSL > 3.x tarballs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,11 +597,11 @@ jobs:
         run: |
           if [ ! -f "openssl-${{ matrix.version }}.tar.gz" ]; then
             case "${{ matrix.version }}" in
-              3.*)
-                tag="openssl-${{ matrix.version }}"
+              0.9.*|1.*)
+                tag="OpenSSL_$(echo "${{ matrix.version }}" | tr . _)"
                 ;;
               *)
-                tag="OpenSSL_$(echo "${{ matrix.version }}" | tr . _)"
+                tag="openssl-${{ matrix.version }}"
                 ;;
             esac
 


### PR DESCRIPTION
Invert the logic for computing the tag name for OpenSSL releases in the OpenSSL GitHub repo - if the version number is below 3.x then use the old-style tag naming scheme, otherwise use the current naming scheme. This will ensure the correct tag name is computed for modern OpenSSL releases.